### PR TITLE
feat: adicionar execução manual aos workflows terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -8,6 +8,13 @@ on:
       - '.github/workflows/terraform-apply.yml'
   repository_dispatch:
     types: [database-ready]
+  workflow_dispatch:
+    inputs:
+      force_deploy:
+        description: 'Force deployment from current branch'
+        required: false
+        type: boolean
+        default: false
 
 env:
   TF_VERSION: '1.5.0'
@@ -93,3 +100,4 @@ jobs:
               trigger_source: 'k8s-infrastructure'
             }
           })
+

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform-plan.yml'
+  workflow_dispatch:
+    inputs:
+      validate_only:
+        description: 'Run validation only (skip plan)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   TF_VERSION: '1.5.0'
@@ -84,3 +91,4 @@ jobs:
         echo "  • Merge this PR to trigger infrastructure deployment"
         echo "  • EKS cluster will be created and configured"
         echo "  • Application can then be deployed automatically"
+


### PR DESCRIPTION
- Adicionar workflow_dispatch ao terraform-apply.yml para deploy manual
- Adicionar workflow_dispatch ao terraform-plan.yml para validação manual
- Incluir inputs para controle granular das operações
- Permite execução de infraestrutura independente de push/PR

Permite deploy manual da infraestrutura Kubernetes