### PR TITLE
feat: add S3 backend configuration for Terraform state

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -10,6 +10,12 @@ terraform {
     }
   }
   required_version = ">= 1.0"
+
+  backend "s3" {
+    bucket = "fastfood-terraform-state-bucket"
+    key    = "infra/terraform.tfstate"
+    region = "us-east-1"
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
- Add S3 backend configuration to store Terraform state remotely
- Use bucket: fastfood-terraform-state-bucket
- Key: infra/terraform.tfstate (specific for k8s infrastructure)
- Region: us-east-1

This enables state sharing and prevents conflicts between deployments